### PR TITLE
Fix save and frog bug

### DIFF
--- a/Frog.gd
+++ b/Frog.gd
@@ -40,24 +40,24 @@ func _on_player_detection_body_exited(body):
 
 
 func _on_player_death_body_entered(body):
-	if body.name == "Player":
-		Game.Gold += 5
-		#bounce on frog head
-		body.velocity.y *= -1
-		death()
+        if body.name == "Player":
+                Game.Gold += 5
+                # bounce on frog head
+                body.velocity.y *= -1
+                death(body)
 
 func _on_player_collision_body_entered(body):
-	if body.name == "Player":
-		Game.playerHp -= 3
-		death()
+        if body.name == "Player":
+                Game.playerHp -= 3
+                death(body)
 
 		
-func death():
-		Game.playerX = player.position.x 
-		Game.playerY = player.position.y
-		Util.saveGame()
-		print(Game.playerHp)
-		chase = false
-		anim2d.play("Death")
-		await anim2d.animation_finished
-		self.queue_free()
+func death(hit_player):
+                Game.playerX = hit_player.position.x
+                Game.playerY = hit_player.position.y
+                Util.saveGame()
+                print(Game.playerHp)
+                chase = false
+                anim2d.play("Death")
+                await anim2d.animation_finished
+                self.queue_free()

--- a/Global/Util.gd
+++ b/Global/Util.gd
@@ -1,28 +1,29 @@
 extends Node
 
 
-const SAVE_PATH = "res://savegame.bin"
+# Use the user folder for the save file so it can be written on any platform
+const SAVE_PATH = "user://savegame.bin"
 
 
 func saveGame():
-	var file = FileAccess.open(SAVE_PATH, FileAccess.WRITE)
-	var data = {
-		"playerHp": Game.playerHp,
-		"Gold": Game.Gold,
-		"playerX": Game.playerX,
-		"playerY": Game.playerY
-	}
+        var file = FileAccess.open(SAVE_PATH, FileAccess.WRITE)
+        var data = {
+                "playerHp": Game.playerHp,
+                "Gold": Game.Gold,
+                "playerX": Game.playerX,
+                "playerY": Game.playerY
+        }
 	
 	var jstr = JSON.stringify(data) #take the Dictionary and stringisy it
-	file.store_line(jstr)#store it
-	
+        file.store_line(jstr)#store it
+
 func loadGame():
-	var file = FileAccess.open(SAVE_PATH, FileAccess.READ)
-	if FileAccess.file_exists(SAVE_PATH) == true:
-		if not file.eof_reached():
-			var current_line = JSON.parse_string(file.get_line())#current will take all the things in the file and convert it into smth godot readable
-			if current_line:
-				Game.playerHp = current_line["playerHp"]
-				Game.Gold = current_line["Gold"]
-				Game.playerX = current_line["playerX"]
-				Game.playerY = current_line["playerY"]
+        if FileAccess.file_exists(SAVE_PATH):
+                var file = FileAccess.open(SAVE_PATH, FileAccess.READ)
+                if not file.eof_reached():
+                        var current_line = JSON.parse_string(file.get_line()) # current will take all the things in the file and convert it into something Godot readable
+                        if current_line:
+                                Game.playerHp = current_line["playerHp"]
+                                Game.Gold = current_line["Gold"]
+                                Game.playerX = current_line["playerX"]
+                                Game.playerY = current_line["playerY"]


### PR DESCRIPTION
## Summary
- use a user folder for saving and guard against missing save file
- pass the Player object to Frog's `death()` function so it never tries to read from a null reference

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd69401c0832b8ee33874fc7484a1